### PR TITLE
feat: add wrappers for promise's concurrent methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+package-lock.json
+.idea/

--- a/src/go/mightFail.ts
+++ b/src/go/mightFail.ts
@@ -65,3 +65,51 @@ export function mightFailSync<T>(func: () => T): Either<T> {
   return error ? [undefined, error] : [result, undefined];
 }
 
+/**
+ * Wraps a Promise.all call in an Either tuple.
+ *
+ * @template T The type of the resolved values.
+ * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
+ * @return {Promise<Either<T[]>>} A Promise that resolves with an Either tuple. If successful, it resolves as
+ * [T[], undefined]. If any promise fails, it returns [undefined, Error] where the error is the first rejection.
+ */
+mightFail.all = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T[]>> {
+  return mightFail(Promise.all(values));
+};
+
+/**
+ * Wraps a Promise.race call in an Either tuple.
+ *
+ * @template T The type of the resolved values.
+ * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
+ * @return {Promise<Either<T>>} A Promise that resolves with an Either tuple. If successful, it resolves as
+ * [T, undefined]. If the first promise fails, it returns [undefined, Error].
+ */
+mightFail.race = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T>> {
+  return mightFail(Promise.race(values));
+};
+
+/**
+ * Wraps a Promise.allSettled call in an Either tuple.
+ *
+ * @template T The type of the resolved values.
+ * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
+ * @return {Promise<Either<PromiseSettledResult<T>[]>>} A Promise that resolves with an Either tuple.
+ * Since Promise.allSettled never rejects, the tuple will always be [PromiseSettledResult<T>[], undefined].
+ */
+mightFail.allSettled = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<PromiseSettledResult<T>[]>> {
+  return mightFail(Promise.allSettled(values));
+};
+
+/**
+ * Wraps a Promise.any call in an Either tuple.
+ *
+ * @template T The type of the resolved values.
+ * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
+ * @return {Promise<Either<T>>} A Promise that resolves with an Either tuple. If successful, it resolves as
+ * [T, undefined]. If all promises fail, it returns [undefined, Error] where the error is an AggregateError.
+ */
+mightFail.any = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T>> {
+  return mightFail(Promise.any(values));
+};
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { type Either } from "./Either";
-import { mightFail, mightFailSync } from "./mightFail";
+import { mightFail, mightFailSync, mightFailFunction } from "./mightFail";
 import { makeMightFail, makeMightFailSync } from "./makeMightFail";
 
-export { Either, mightFail, makeMightFail, mightFailSync, makeMightFailSync };
-export default { mightFail, makeMightFail, mightFailSync, makeMightFailSync };
+export { Either, mightFail, makeMightFail, mightFailSync, makeMightFailSync, mightFailFunction };
+export default { mightFail, makeMightFail, mightFailSync, makeMightFailSync, mightFailFunction };

--- a/src/makeMightFail.ts
+++ b/src/makeMightFail.ts
@@ -1,5 +1,5 @@
 import { type Either } from "./Either";
-import { mightFail, mightFailSync } from "./mightFail";
+import { mightFailSync, mightFailFunction } from "./mightFail";
 
 /**
  * Utility type that unwraps a Promise type. If T is a Promise, it extracts the type the Promise resolves to,
@@ -46,7 +46,7 @@ export function makeMightFail<T extends (...args: any[]) => Promise<any>>(
 ) => Promise<Either<UnwrapPromise<ReturnType<T>>>> {
   return async (...args: Parameters<T>) => {
     const promise = func(...args);
-    return mightFail(promise);
+    return mightFailFunction(promise) as Promise<Either<any>>;
   };
 }
 

--- a/src/mightFail.ts
+++ b/src/mightFail.ts
@@ -76,3 +76,100 @@ export function mightFailSync<T>(func: () => T): Either<T> {
     return { error, result: undefined };
   }
 }
+
+/**
+ * Wraps a Promise.all call in a mightFail function.
+ *
+ * @export
+ * @template T The type of the resolved values
+ * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises
+ * @return {Either<T[]>} A `Promise` that resolves with an Either object which has a 'result' property as Success<T[]>
+ * set to the values resolved by the promise if successful, and 'error' property as undefined.
+ * In case of failure, it's a Failure with 'result' as undefined and 'error' of type `Error`. `error` will **always** be an instance of `Error`.
+ * The error value will be the first error encountered in the `Promise.all` call.
+ *
+ * @example
+ * // Example of wrapping a Promise.all call in a mightFail function:
+ * const {error, result} = await mightFail.all([Promise.resolve(1), Promise.reject(new Error("error"))]);
+ *
+ * if (error) {
+ *   console.error('Promise.all failed:', error.message);
+ *   return;
+ * }
+ * console.log('Promise.all resolved:', result);
+ */
+mightFail.all = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T[]>> {
+  return mightFail(Promise.all(values));
+};
+
+/**
+ * Wraps a Promise.race call in a mightFail function.
+ *
+ * @export
+ * @template T The type of the resolved values
+ * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises
+ * @return {Promise<Either<T>>} A `Promise` that resolves with an Either object which has a property 'result' as Success<T>
+ * set to the value resolved by the Promise.race if successful, and 'error' as undefined.
+ * In case of failure, it's a Failure with 'result' as undefined and 'error' of type `Error`. `error` will **always** be an instance of `Error`.
+ * The error will be the first error encountered in the `Promise.race` call.
+ *
+ * @example
+ * // Example of wrapping a Promise.race call in a mightFail function:
+ * const {error, result} = await mightFail.race([Promise.resolve(1), Promise.reject(new Error("error"))]);
+ *
+ * if (error) {
+ *   console.error('Promise.race failed:', error.message);
+ *   return;
+ * }
+ * console.log('Promise.race resolved:', result);
+ */
+mightFail.race = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T>> {
+  return mightFail(Promise.race(values));
+};
+
+/**
+ * Wraps a Promise.allSettled call in a mightFail function.
+ *
+ * @export
+ * @template T The type of the resolved values
+ * @param {Iterable<T | PromiseLike<T>>} values The values to be resolved
+ * @return {Promise<Either<PromiseSettledResult<T>[]>>} A `Promise` that resolves with an `Either` which has a `Success<PromiseSettledResult<T>[]>` with
+ * the 'result' property set to the value resolved by the promise if successful, and 'error' as undefined.
+ * This method will always resolve with an array of `PromiseSettledResult` objects, even if some of the promises in the iterable are rejected.
+ * Hence, the error property will always be undefined.
+ *
+ * @example
+ * // Example of wrapping a Promise.allSettled call in a mightFail function:
+ * const {result: settledPromises} = await mightFail.allSettled([Promise.resolve(1), Promise.reject(new Error("error"))]);
+ *
+ * console.log('Promise.allSettled resolved:', settledPromises);
+ */
+mightFail.allSettled = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<PromiseSettledResult<T>[]>> {
+  return mightFail(Promise.allSettled(values));
+};
+
+/**
+ * Wraps a Promise.any call in a mightFail function.
+ *
+ * @export
+ * @template T The type of the resolved values
+ * @param {Iterable<T | PromiseLike<T>>} values The values to be resolved
+ * @return {Promise<Either<T>>} A `Promise` that resolves with an `Either` which has a `Success<T>` with
+ * the 'result' property set to the value resolved by the promise if successful, and 'error' as undefined.
+ * In case of failure, it's a Failure with 'result' as undefined and 'error' of type `Error`. `error` will **always** be an instance of `Error`.
+ *
+ * This method will reject only if all the promises in the iterable are rejected.
+ *
+ * @example
+ * // Example of wrapping a Promise.any call in a mightFail function:
+ * const {error, result} = await mightFail.any([Promise.resolve(1), Promise.reject(new Error("error"))]);
+ *
+ * if (error) {
+ *   console.error('Promise.any failed:', error.message);
+ *   return;
+ * }
+ * console.log('Promise.any resolved:', result);
+ */
+mightFail.any = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T>> {
+  return mightFail(Promise.any(values));
+};

--- a/src/tuple/mightFail.ts
+++ b/src/tuple/mightFail.ts
@@ -1,5 +1,15 @@
 import standard from "../index";
 import { type Either } from "./Either";
+import { makeProxyHandler } from "../utils";
+import { MightFail, MightFailFunction } from "../utils.type";
+
+const mightFailFunction: MightFailFunction<'tuple'> = async function <T>(
+    promise: Promise<T>
+) {
+  const {result, error} = await standard.mightFailFunction(promise);
+  return error ? [error, undefined] : [undefined, result];
+};
+
 /**
  * Wraps a promise in an Either tuple to safely handle both its resolution and rejection. This function
  * takes a Promise of type T and returns a Promise which resolves with an Either tuple. This tuple
@@ -32,10 +42,10 @@ import { type Either } from "./Either";
  * }
  * console.log('Fetched data:', result);
  */
-export async function mightFail<T>(promise: Promise<T>): Promise<Either<T>> {
-  const {result, error} = await standard.mightFail(promise);
-  return error ? [error, undefined] : [undefined, result];
-}
+export const mightFail: MightFail<'tuple'> = new Proxy(
+    mightFailFunction,
+    makeProxyHandler(mightFailFunction)
+) as MightFail<'tuple'>;
 
 /**
  * Wraps a synchronous function in an Either tuple to safely handle exceptions. This function
@@ -64,52 +74,3 @@ export function mightFailSync<T>(func: () => T): Either<T> {
   const {result, error} = standard.mightFailSync(func);
   return error ? [error, undefined] : [undefined, result];
 }
-
-/**
- * Wraps a Promise.all call in an Either tuple.
- *
- * @template T The type of the resolved values.
- * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
- * @return {Promise<Either<T[]>>} A Promise that resolves with an Either tuple. If successful, it resolves as
- * [undefined, T[]]. If any promise fails, it returns [Error, undefined] where the error is the first rejection.
- */
-mightFail.all = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T[]>> {
-  return mightFail(Promise.all(values));
-};
-
-/**
- * Wraps a Promise.race call in an Either tuple.
- *
- * @template T The type of the resolved values.
- * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
- * @return {Promise<Either<T>>} A Promise that resolves with an Either tuple. If successful, it resolves as
- * [undefined, T]. If the first promise fails, it returns [Error, undefined].
- */
-mightFail.race = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T>> {
-  return mightFail(Promise.race(values));
-};
-
-/**
- * Wraps a Promise.allSettled call in an Either tuple.
- *
- * @template T The type of the resolved values.
- * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
- * @return {Promise<Either<PromiseSettledResult<T>[]>>} A Promise that resolves with an Either tuple.
- * Since Promise.allSettled never rejects, the tuple will always be [undefined, PromiseSettledResult<T>[]].
- */
-mightFail.allSettled = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<PromiseSettledResult<T>[]>> {
-  return mightFail(Promise.allSettled(values));
-};
-
-/**
- * Wraps a Promise.any call in an Either tuple.
- *
- * @template T The type of the resolved values.
- * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
- * @return {Promise<Either<T>>} A Promise that resolves with an Either tuple. If successful, it resolves as
- * [undefined, T]. If all promises fail, it returns [Error, undefined] where the error is an AggregateError.
- */
-mightFail.any = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T>> {
-  return mightFail(Promise.any(values));
-};
-

--- a/src/tuple/mightFail.ts
+++ b/src/tuple/mightFail.ts
@@ -65,3 +65,51 @@ export function mightFailSync<T>(func: () => T): Either<T> {
   return error ? [error, undefined] : [undefined, result];
 }
 
+/**
+ * Wraps a Promise.all call in an Either tuple.
+ *
+ * @template T The type of the resolved values.
+ * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
+ * @return {Promise<Either<T[]>>} A Promise that resolves with an Either tuple. If successful, it resolves as
+ * [undefined, T[]]. If any promise fails, it returns [Error, undefined] where the error is the first rejection.
+ */
+mightFail.all = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T[]>> {
+  return mightFail(Promise.all(values));
+};
+
+/**
+ * Wraps a Promise.race call in an Either tuple.
+ *
+ * @template T The type of the resolved values.
+ * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
+ * @return {Promise<Either<T>>} A Promise that resolves with an Either tuple. If successful, it resolves as
+ * [undefined, T]. If the first promise fails, it returns [Error, undefined].
+ */
+mightFail.race = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T>> {
+  return mightFail(Promise.race(values));
+};
+
+/**
+ * Wraps a Promise.allSettled call in an Either tuple.
+ *
+ * @template T The type of the resolved values.
+ * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
+ * @return {Promise<Either<PromiseSettledResult<T>[]>>} A Promise that resolves with an Either tuple.
+ * Since Promise.allSettled never rejects, the tuple will always be [undefined, PromiseSettledResult<T>[]].
+ */
+mightFail.allSettled = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<PromiseSettledResult<T>[]>> {
+  return mightFail(Promise.allSettled(values));
+};
+
+/**
+ * Wraps a Promise.any call in an Either tuple.
+ *
+ * @template T The type of the resolved values.
+ * @param {Iterable<T | PromiseLike<T>>} values An iterable of promises.
+ * @return {Promise<Either<T>>} A Promise that resolves with an Either tuple. If successful, it resolves as
+ * [undefined, T]. If all promises fail, it returns [Error, undefined] where the error is an AggregateError.
+ */
+mightFail.any = function<T>(values: Iterable<T | PromiseLike<T>>): Promise<Either<T>> {
+  return mightFail(Promise.any(values));
+};
+

--- a/src/utils.type.ts
+++ b/src/utils.type.ts
@@ -1,0 +1,61 @@
+import type { Either as StandardEither } from "./Either";
+import type { Either as TupleEither } from "./tuple";
+import type { Either as GoEither } from "./go";
+
+export type EitherMode = 'standard' | 'tuple' | 'go' | 'any';
+
+export type AnyEither<T> = StandardEither<T> | TupleEither<T> | GoEither<T>;
+
+export type MightFailFunction<TEitherMode extends EitherMode> = <T>(promise: Promise<T>) => Promise<
+    TEitherMode extends 'standard' ? StandardEither<T> :
+        TEitherMode extends 'tuple' ? TupleEither<T> :
+            TEitherMode extends 'go' ? GoEither<T> :
+                AnyEither<T>
+>;
+
+export type MightFail<TEitherMode extends EitherMode, TPromiseStaticMethods = PromiseStaticMethods<TEitherMode>> = MightFailFunction<TEitherMode> & TPromiseStaticMethods;
+
+export interface PromiseStaticMethods<TEitherMode extends EitherMode> {
+    /**
+     * Wraps a Promise.all call in a mightFail function.
+     * @param values
+     */
+    all<T>(values: Iterable<T | PromiseLike<T>>): Promise<
+        TEitherMode extends 'standard' ? StandardEither<T[]> :
+            TEitherMode extends 'tuple' ? TupleEither<T[]> :
+                TEitherMode extends 'go' ? GoEither<T[]> :
+                    AnyEither<T[]>
+    >;
+    /**
+     * Wraps a Promise.race call in a mightFail function.
+     * @param values
+     */
+    race<T>(values: Iterable<T | PromiseLike<T>>): Promise<
+        TEitherMode extends 'standard' ? StandardEither<T[]> :
+            TEitherMode extends 'tuple' ? TupleEither<T[]> :
+                TEitherMode extends 'go' ? GoEither<T[]> :
+                    AnyEither<T[]>
+    >;
+    /**
+     * Wraps a Promise.allSettled call in a mightFail function.
+     * @param values
+     */
+    allSettled<T>(
+        values: Iterable<T | PromiseLike<T>>
+    ): Promise<AnyEither<
+        TEitherMode extends 'standard' ? StandardEither<PromiseSettledResult<T>[]> :
+            TEitherMode extends 'tuple' ? TupleEither<PromiseSettledResult<T>[]> :
+                TEitherMode extends 'go' ? GoEither<PromiseSettledResult<T>[]> :
+                    AnyEither<PromiseSettledResult<T>[]>
+    >>;
+    /**
+     * Wraps a Promise.any call in a mightFail function.
+     * @param values
+     */
+    any<T>(values: Iterable<T | PromiseLike<T>>): Promise<
+        TEitherMode extends 'standard' ? StandardEither<T> :
+            TEitherMode extends 'tuple' ? TupleEither<T> :
+                TEitherMode extends 'go' ? GoEither<T> :
+                    AnyEither<T>
+    >;
+}

--- a/src/utils.type.ts
+++ b/src/utils.type.ts
@@ -19,6 +19,8 @@ export interface PromiseStaticMethods<TEitherMode extends EitherMode> {
     /**
      * Wraps a Promise.all call in a mightFail function.
      * @param values
+     * @template T The type of the resolved values
+     * @returns {Promise<Either<T[]>>}
      */
     all<T>(values: Iterable<T | PromiseLike<T>>): Promise<
         TEitherMode extends 'standard' ? StandardEither<T[]> :
@@ -29,28 +31,34 @@ export interface PromiseStaticMethods<TEitherMode extends EitherMode> {
     /**
      * Wraps a Promise.race call in a mightFail function.
      * @param values
+     * @template T The type of the resolved values
+     * @returns {Promise<Either<T>>}
      */
     race<T>(values: Iterable<T | PromiseLike<T>>): Promise<
-        TEitherMode extends 'standard' ? StandardEither<T[]> :
-            TEitherMode extends 'tuple' ? TupleEither<T[]> :
-                TEitherMode extends 'go' ? GoEither<T[]> :
-                    AnyEither<T[]>
+        TEitherMode extends 'standard' ? StandardEither<T> :
+            TEitherMode extends 'tuple' ? TupleEither<T> :
+                TEitherMode extends 'go' ? GoEither<T> :
+                    AnyEither<T>
     >;
     /**
      * Wraps a Promise.allSettled call in a mightFail function.
      * @param values
+     * @template T The type of the resolved values
+     * @returns {Promise<Either<PromiseSettledResult<T>[]>>}
      */
     allSettled<T>(
         values: Iterable<T | PromiseLike<T>>
-    ): Promise<AnyEither<
+    ): Promise<
         TEitherMode extends 'standard' ? StandardEither<PromiseSettledResult<T>[]> :
             TEitherMode extends 'tuple' ? TupleEither<PromiseSettledResult<T>[]> :
                 TEitherMode extends 'go' ? GoEither<PromiseSettledResult<T>[]> :
                     AnyEither<PromiseSettledResult<T>[]>
-    >>;
+    >;
     /**
      * Wraps a Promise.any call in a mightFail function.
      * @param values
+     * @template T The type of the resolved values
+     * @returns {Promise<Either<T>>}
      */
     any<T>(values: Iterable<T | PromiseLike<T>>): Promise<
         TEitherMode extends 'standard' ? StandardEither<T> :

--- a/test/go/mightFail.test.ts
+++ b/test/go/mightFail.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import {describe, expect, it, test } from "vitest";
 import { mightFail } from "../../src/go/index";
 
 test("success returns the response", async () => {
@@ -57,3 +57,70 @@ test("promise that rejects after delay", async () => {
   expect(result).toBe(undefined);
   expect(error?.message).toBe("delayed error");
 });
+
+
+describe('promise concurrent method wrappers', () => {
+  describe('mightFail.all', () => {
+    it('should resolve with all values when all promises succeed', async () => {
+      const promises = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
+      const [result, error] = await mightFail.all(promises);
+      expect(result).toEqual([1, 2, 3]);
+      expect(error).toBeUndefined();
+    });
+
+    it('should return an error if any promise fails', async () => {
+      const promises = [Promise.resolve(1), Promise.reject(new Error('Test Error')), Promise.resolve(3)];
+      const [result, error] = await mightFail.all(promises);
+      expect(result).toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error!.message).toBe('Test Error');
+    });
+  });
+
+  describe('mightFail.race', () => {
+    it('should resolve with the first resolved value', async () => {
+      const promises = [Promise.resolve(42), new Promise(resolve => setTimeout(() => resolve(100), 100))];
+      const [result, error] = await mightFail.race(promises);
+      expect(result).toBe(42);
+      expect(error).toBeUndefined();
+    });
+
+    it('should return an error if the first promise to settle is a rejection', async () => {
+      const promises = [Promise.reject(new Error('Race Error')), Promise.resolve(100)];
+      const [result, error] = await mightFail.race(promises);
+      expect(result).toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect(error!.message).toBe('Race Error');
+    });
+  });
+
+  describe('mightFail.allSettled', () => {
+    it('should resolve with all settled results, including fulfilled and rejected promises', async () => {
+      const promises = [Promise.resolve(1), Promise.reject(new Error('AllSettled Error')), Promise.resolve(3)];
+      const [result, error] = await mightFail.allSettled(promises);
+      expect(result).toEqual([
+        { status: 'fulfilled', value: 1 },
+        { status: 'rejected', reason: new Error('AllSettled Error') },
+        { status: 'fulfilled', value: 3 },
+      ]);
+      expect(error).toBeUndefined();
+    });
+  });
+
+  describe('mightFail.any', () => {
+    it('should resolve with the first successful promise', async () => {
+      const promises = [Promise.reject(new Error('Error 1')), Promise.resolve(200), Promise.reject(new Error('Error 2'))];
+      const [result, error] = await mightFail.any(promises);
+      expect(result).toBe(200);
+      expect(error).toBeUndefined();
+    });
+
+    it('should return an AggregateError if all promises fail', async () => {
+      const promises = [Promise.reject(new Error('Error 1')), Promise.reject(new Error('Error 2'))];
+      const [result, error] = await mightFail.any(promises);
+      expect(result).toBeUndefined();
+      expect(error).toBeInstanceOf(AggregateError);
+      expect(error!.message).toBe('All promises were rejected');
+    });
+  });
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2021",
+    "target": "es2018",
     "module": "esnext",
-    "lib": ["es2021", "dom"],
+    "lib": ["es2018", "dom"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2021",
     "module": "esnext",
-    "lib": ["es2018", "dom"],
+    "lib": ["es2021", "dom"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## What
I realized it'd be nice to have a set of wrapper methods for Promise concurrent functions (e.g.: `Promise.all`, `Promise.race`, `Promise.allSettled`, and `Promise.any`).

## Why
Having to manually wrap these methods, you'll have something like:
```ts
const either = await mightFail(
  Promise.any([
    Promise.resolve(1),
    Promise.reject(new Error("Rejected")),
  ])
)
```

vs. if there was a built-in method in `might-fail` library, it'd look like:
```ts
const either = await mightFail.any([
    Promise.resolve(1),
    Promise.reject(new Error("Rejected")),
])
```