### PR TITLE
feat: create Might and Fail constructors to help creating Either types

### DIFF
--- a/src/go/index.ts
+++ b/src/go/index.ts
@@ -2,11 +2,11 @@
    * @module
    *
    * This module contains the interface to use the result of mightFail as an error-last tuple.
-   * 
+   *
    * This aligns with the proposal-safe-assignment-operator: https://github.com/arthurfiorette/proposal-safe-assignment-operator?tab=readme-ov-file#why-not-data-first
    *
    * If you want to use error-last style, just like golang, use the `/go` module.
-   * 
+   *
 +  * @example
 +  * ```ts
 +  * import { mightFail } from "@might/fail/tuple";
@@ -16,8 +16,8 @@
    */
 
 import { type Either } from "./Either"
-import { mightFail, mightFailSync } from "./mightFail"
+import { mightFail, mightFailSync, Might, Fail } from "./mightFail"
 import { makeMightFail, makeMightFailSync } from "./makeMightFail"
 
-export { Either, mightFail, makeMightFail, mightFailSync, makeMightFailSync }
-export default { mightFail, makeMightFail, mightFailSync, makeMightFailSync }
+export { Either, mightFail, makeMightFail, mightFailSync, makeMightFailSync, Might, Fail }
+export default { mightFail, makeMightFail, mightFailSync, makeMightFailSync, Might, Fail }

--- a/src/go/mightFail.ts
+++ b/src/go/mightFail.ts
@@ -1,7 +1,7 @@
 import standard from "../index"
 import { type Either } from "./Either"
 import { makeProxyHandler } from "../utils"
-import { MightFail, MightFailFunction } from "../utils.type"
+import { MightFail, MightFailFunction, NonUndefined } from "../utils.type"
 
 const mightFailFunction: MightFailFunction<"go"> = async function <T>(promise: Promise<T>) {
   const { result, error } = await standard.mightFailFunction(promise)
@@ -70,4 +70,29 @@ export const mightFail: MightFail<"go"> = new Proxy(
 export function mightFailSync<T>(func: () => T): Either<T> {
   const { result, error } = standard.mightFailSync(func)
   return error ? [undefined, error] : [result, undefined]
+}
+
+
+/**
+ * A pure constructor function that takes a non-null value and returns an Either object with the value as the result and undefined as the error.
+ *
+ * @param result
+ * @constructor
+ */
+export function Might<T>(result: NonUndefined<T>): Either<T> {
+  const standardMight = standard.Might<T>(result)
+  return [standardMight.result as T, undefined]
+}
+
+/**
+ * A constructor function that takes an error and returns an Either object with undefined as the result and the error as the error.
+ *
+ * The error will **always** be an instance of Error.
+ *
+ * @param error
+ * @constructor
+ */
+export function Fail(error: unknown): Either<undefined> {
+  const standardFail = standard.Fail(error)
+  return [undefined, standardFail.error]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { type Either } from "./Either"
-import { mightFail, mightFailSync, mightFailFunction } from "./mightFail"
+import { mightFail, mightFailSync, mightFailFunction, Might, Fail } from "./mightFail"
 import { makeMightFail, makeMightFailSync } from "./makeMightFail"
 
-export { Either, mightFail, makeMightFail, mightFailSync, makeMightFailSync, mightFailFunction }
-export default { mightFail, makeMightFail, mightFailSync, makeMightFailSync, mightFailFunction }
+export { Either, mightFail, makeMightFail, mightFailSync, makeMightFailSync, mightFailFunction, Might, Fail }
+export default { mightFail, makeMightFail, mightFailSync, makeMightFailSync, mightFailFunction, Might, Fail }

--- a/src/mightFail.ts
+++ b/src/mightFail.ts
@@ -1,6 +1,6 @@
 import { type Either } from "./Either"
 import { handleError, makeProxyHandler } from "./utils"
-import { MightFail, MightFailFunction } from "./utils.type"
+import { MightFail, MightFailFunction, NonUndefined } from "./utils.type"
 
 export const mightFailFunction: MightFailFunction<"standard"> = async function <T>(
   promise: Promise<T>
@@ -83,4 +83,27 @@ export function mightFailSync<T>(func: () => T): Either<T> {
     const error = handleError(err)
     return { error, result: undefined }
   }
+}
+
+
+/**
+ * A pure constructor function that takes a non-null value and returns an Either object with the value as the result and undefined as the error.
+ *
+ * @param result
+ * @constructor
+ */
+export function Might<T>(result: NonUndefined<T>): Either<T> {
+  return { result, error: undefined }
+}
+
+/**
+ * A constructor function that takes an error and returns an Either object with undefined as the result and the error as the error.
+ *
+ * The error will **always** be an instance of Error.
+ *
+ * @param error
+ * @constructor
+ */
+export function Fail(error: unknown): Either<undefined> {
+  return { result: undefined, error: handleError(error) }
 }

--- a/src/tuple/index.ts
+++ b/src/tuple/index.ts
@@ -2,11 +2,11 @@
    * @module
    *
    * This module contains the interface to use the result of mightFail as an error-first tuple.
-   * 
+   *
    * This mimics the behaviour of golang.
    *
    * If you want to use error-first style, use the `/tuple` module.
-   * 
+   *
 +  * @example
 +  * ```ts
 +  * import { mightFail } from "@might/fail/tuple";
@@ -16,8 +16,8 @@
    */
 
 import { type Either } from "./Either"
-import { mightFail, mightFailSync } from "./mightFail"
+import { mightFail, mightFailSync, Might, Fail } from "./mightFail"
 import { makeMightFail, makeMightFailSync } from "./makeMightFail"
 
-export { Either, mightFail, makeMightFail, mightFailSync, makeMightFailSync }
-export default { mightFail, makeMightFail, mightFailSync, makeMightFailSync }
+export { Either, mightFail, makeMightFail, mightFailSync, makeMightFailSync, Might, Fail }
+export default { mightFail, makeMightFail, mightFailSync, makeMightFailSync, Might, Fail }

--- a/src/tuple/mightFail.ts
+++ b/src/tuple/mightFail.ts
@@ -1,7 +1,7 @@
 import standard from "../index"
 import { type Either } from "./Either"
 import { makeProxyHandler } from "../utils"
-import { MightFail, MightFailFunction } from "../utils.type"
+import { MightFail, MightFailFunction, NonUndefined } from "../utils.type"
 
 const mightFailFunction: MightFailFunction<"tuple"> = async function <T>(promise: Promise<T>) {
   const { result, error } = await standard.mightFailFunction(promise)
@@ -71,4 +71,29 @@ export const mightFail: MightFail<"tuple"> = new Proxy(
 export function mightFailSync<T>(func: () => T): Either<T> {
   const { result, error } = standard.mightFailSync(func)
   return error ? [error, undefined] : [undefined, result]
+}
+
+
+/**
+ * A pure constructor function that takes a non-null value and returns an Either object with the value as the result and undefined as the error.
+ *
+ * @param result
+ * @constructor
+ */
+export function Might<T>(result: NonUndefined<T>): Either<T> {
+  const standardMight = standard.Might<T>(result)
+  return [undefined, standardMight.result as T]
+}
+
+/**
+ * A constructor function that takes an error and returns an Either object with undefined as the result and the error as the error.
+ *
+ * The error will **always** be an instance of Error.
+ *
+ * @param error
+ * @constructor
+ */
+export function Fail(error: unknown): Either<undefined> {
+  const standardFail = standard.Fail(error)
+  return [standardFail.error, undefined]
 }

--- a/src/utils.type.ts
+++ b/src/utils.type.ts
@@ -181,3 +181,5 @@ export interface PromiseStaticMethods<TEitherMode extends EitherMode> {
       : AnyEither<Awaited<T>>
   >
 }
+
+export type NonUndefined<T> = T extends undefined ? never : T

--- a/test/go/mightFail.test.ts
+++ b/test/go/mightFail.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "vitest"
-import { mightFail } from "../../src/go/index"
+import { mightFail, Might, Fail } from "../../src/go/index"
 
 test("success returns the response", async () => {
   const [result, error] = await mightFail(Promise.resolve("success"))
@@ -120,6 +120,28 @@ describe("promise concurrent method wrappers", () => {
       expect(result).toBeUndefined()
       expect(error).toBeInstanceOf(Error)
       expect(error!.message).toBe("All promises were rejected")
+    })
+  })
+})
+
+describe("Either factories (Might & Fail)", () => {
+  describe("Might", () => {
+    it("should return an Either with the value as the result and undefined as the error", () => {
+      const result = Might(5)
+      expect(result).toEqual([5, undefined])
+    })
+  })
+  describe("Fail", () => {
+    it("should return an Either with undefined as the result and the error as the error", () => {
+      const error = new Error("error")
+      const result = Fail(error)
+      expect(result).toEqual([undefined, error])
+    })
+
+    it("should return an Either with undefined as the result and the error must be an instance of Error", () => {
+      const error = "error"
+      const result = Fail(error)
+      expect(result).toEqual([undefined, new Error(error)])
     })
   })
 })

--- a/test/mightFail.test.ts
+++ b/test/mightFail.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "vitest"
-import { mightFail } from "../src/index"
+import { mightFail, Might, Fail } from "../src/index"
 
 test("success returns the response", async () => {
   const { error, result } = await mightFail(Promise.resolve("success"))
@@ -116,6 +116,37 @@ describe("promise concurrent method wrappers", () => {
       expect(result).toBeUndefined()
       expect(error).toBeInstanceOf(Error)
       expect(error!.message).toBe("All promises were rejected")
+    })
+  })
+})
+
+describe("Either factories (Might & Fail)", () => {
+  describe("Might", () => {
+    it("should return an Either with the value as the result and undefined as the error", () => {
+      const result = Might(5)
+      expect(result).toEqual({
+        result: 5,
+        error: undefined
+      })
+    })
+  })
+  describe("Fail", () => {
+    it("should return an Either with undefined as the result and the error as the error", () => {
+      const error = new Error("error")
+      const result = Fail(error)
+      expect(result).toEqual({
+        result: undefined,
+        error
+      })
+    })
+
+    it("should return an Either with undefined as the result and the error must be an instance of Error", () => {
+      const error = "error"
+      const result = Fail(error)
+      expect(result).toEqual({
+        result: undefined,
+        error: new Error(error)
+      })
     })
   })
 })

--- a/test/tuple/mightFail.test.ts
+++ b/test/tuple/mightFail.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "vitest"
-import { mightFail } from "../../src/tuple/index"
+import { mightFail, Might, Fail } from "../../src/tuple/index"
 
 test("success returns the response", async () => {
   const [error, result] = await mightFail(Promise.resolve("success"))
@@ -120,6 +120,28 @@ describe("promise concurrent method wrappers", () => {
       expect(result).toBeUndefined()
       expect(error).toBeInstanceOf(Error)
       expect(error!.message).toBe("All promises were rejected")
+    })
+  })
+})
+
+describe("Either factories (Might & Fail)", () => {
+  describe("Might", () => {
+    it("should return an Either with the value as the result and undefined as the error", () => {
+      const result = Might(5)
+      expect(result).toEqual([undefined, 5])
+    })
+  })
+  describe("Fail", () => {
+    it("should return an Either with undefined as the result and the error as the error", () => {
+      const error = new Error("error")
+      const result = Fail(error)
+      expect(result).toEqual([error, undefined])
+    })
+
+    it("should return an Either with undefined as the result and the error must be an instance of Error", () => {
+      const error = "error"
+      const result = Fail(error)
+      expect(result).toEqual([new Error(error), undefined])
     })
   })
 })


### PR DESCRIPTION
## What
Two new functions that construct an Either type that helps when directly working with the Either type. 

## Why
In cases where the user wants to return an Either created manually, the code would look like this: 
```ts
import { Either } from 'might-fail/tuple'

export async function foo(): Either<boolean> {
  // ...

  if (condition) {
    return [new Error("Something went wrong", undefined]
  }

  if (condition2) {
    return [new Error("Something else went wrong", undefined]
  }
  
  return [undefined, true]
}
```

But with this change, the code can be much simpler to write and read.
```ts
import { Either, Might, Fail } from 'might-fail/tuple'

export async function foo(): Either<boolean> {
  // ...

  if (condition) {
    //   notice that we don't have to wrap the string to an Error construct 
    // because Fail will automatically wraps it in Error for us.
    return Fail("Something went wrong") 
  }

  if (condition2) {
    return Fail("Something else went wrong") 
  }
  
  return Might(true)
}
```

Note that, one is not allowed to pass `undefined` to the `Might` function. Because that is against the rule of `Either` type. 

Of course, this is just **my** opinion and technically, TypeScript does not care if `T` is `undefined`. But, I made the `Might` function specifically in a way that won't accept `undefined` as its parameter.

```ts
//  Either should not have both sides as `undefined`
// export type Either<T> = [Error, undefined] | [undefined, T]

import { Either, Might } from 'might-fail/tuple'

const undefinedAsResult = Might(undefined) // ❌ This is not OK. TypeScript won't allow it.

const explicitlyEmpty = Might(null) // ✅ This is fine because it doesn't go against the rule of the Either concept
```