### PR TITLE
feat(prettier): enforce a consistent endOfLine and tailingComma

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,7 @@
   "tabWidth": 2,
   "useTabs": false,
   "semi": false,
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "crlf",
+  "trailingComma": "none"
 }


### PR DESCRIPTION
I've been having to undo my changes because the end of lines are different. Same with trailing commas