### PR TITLE
Fix CJS compatibility (use .cjs file extensions)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.3] - 2024-12-11
+
+### Changed
+- Fixed the error type to make it more generic and consistent with TS: https://github.com/might-fail/ts/issues/20
+
 ## [0.7.2] - 2024-11-30
 
 ### Changed

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@might/fail",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "exports": {
     ".": "./src/index.ts",
     "./go": "./src/go/index.ts"

--- a/package.json
+++ b/package.json
@@ -2,19 +2,19 @@
   "name": "might-fail",
   "version": "0.7.3",
   "description": "A better way to handle errors in JavaScript and TypeScript. Handle async and sync errors without `try` and `catch` blocks.",
-  "main": "dist/cjs/index.js",
+  "main": "dist/cjs/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/cjs/index.js",
+      "require": "./dist/cjs/index.cjs",
       "types": "./dist/index.d.ts"
     },
     "./go": {
       "import": "./dist/go/index.js",
-      "require": "./dist/cjs/go/index.js",
+      "require": "./dist/cjs/go/index.cjs",
       "types": "./dist/go/index.d.ts"
     }
   },
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.cjs",
     "dist/**/*.d.ts",
     "dist/**/*.ts"
   ],
@@ -61,4 +62,3 @@
     "vitest": "^2.1.1"
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "might-fail",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A better way to handle errors in JavaScript and TypeScript. Handle async and sync errors without `try` and `catch` blocks.",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
The package was encountering CommonJS compatibility issues when used in our CJS project. This was due to the `"type": "module"` of `package.json`. 
I initially tried to fix the issue by just copying the `package.cjs.json` to `dist/cjs`, but it didn't seem to be copied over properly when downloaded from the npm registry (using pnpm), even though it was there when I inspected the local build results.

This PR addresses the issue by:
1. Adding .cjs extension to CommonJS output files
2. Adding a plugin to fix require() statements to reference .cjs files

Not sure if this is the preferred approach, but it fixed the issues in our environment.