### PR TITLE
fix(#25): include `.js` extensions for `NodeNext` module resolution

### DIFF
--- a/src/go/index.ts
+++ b/src/go/index.ts
@@ -15,9 +15,9 @@
 +  * ```
    */
 
-import { type Either } from "./Either"
-import { mightFail, mightFailSync, Might, Fail } from "./mightFail"
-import { makeMightFail, makeMightFailSync } from "./makeMightFail"
+import { type Either } from "./Either.js"
+import { mightFail, mightFailSync, Might, Fail } from "./mightFail.js"
+import { makeMightFail, makeMightFailSync } from "./makeMightFail.js"
 
 export { Either, mightFail, makeMightFail, mightFailSync, makeMightFailSync, Might, Fail }
 const defaultExport = {

--- a/src/go/makeMightFail.ts
+++ b/src/go/makeMightFail.ts
@@ -1,5 +1,5 @@
-import { type Either } from "./Either"
-import { mightFail, mightFailSync } from "./mightFail"
+import { type Either } from "./Either.js"
+import { mightFail, mightFailSync } from "./mightFail.js"
 
 /**
  * Utility type that unwraps a Promise type. If T is a Promise, it extracts the type the Promise resolves to,

--- a/src/go/mightFail.ts
+++ b/src/go/mightFail.ts
@@ -1,9 +1,9 @@
-import standard from "../index"
-import { type Either } from "./Either"
-import { createEither } from "../utils/createEither"
-import { makeProxyHandler } from "../utils/staticMethodsProxy"
-import { MightFail, MightFailFunction } from "../utils/utils.type"
-import { mightFailFunction as standardMightFailFunction } from "../utils/mightFailFunction"
+import standard from "../index.js"
+import { type Either } from "./Either.js"
+import { createEither } from "../utils/createEither.js"
+import { makeProxyHandler } from "../utils/staticMethodsProxy.js"
+import { MightFail, MightFailFunction } from "../utils/utils.type.js"
+import { mightFailFunction as standardMightFailFunction } from "../utils/mightFailFunction.js"
 
 const mightFailFunction: MightFailFunction<"go"> = async function <T, E extends Error = Error>(promise: T) {
   const { result, error } = await standardMightFailFunction(promise)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { type Either } from "./Either"
-import { mightFail, mightFailSync, Might, Fail } from "./mightFail"
-import { makeMightFail, makeMightFailSync } from "./makeMightFail"
+import { type Either } from "./Either.js"
+import { mightFail, mightFailSync, Might, Fail } from "./mightFail.js"
+import { makeMightFail, makeMightFailSync } from "./makeMightFail.js"
 
 export { Either, mightFail, makeMightFail, mightFailSync, makeMightFailSync, Might, Fail }
 const defaultExport = {

--- a/src/makeMightFail.ts
+++ b/src/makeMightFail.ts
@@ -1,5 +1,5 @@
-import { type Either } from "./Either"
-import { mightFail, mightFailSync } from "./mightFail"
+import { type Either } from "./Either.js"
+import { mightFail, mightFailSync } from "./mightFail.js"
 
 /**
  * Utility type that unwraps a Promise type. If T is a Promise, it extracts the type the Promise resolves to,

--- a/src/mightFail.ts
+++ b/src/mightFail.ts
@@ -1,9 +1,9 @@
-import { type Either } from "./Either"
-import { makeProxyHandler } from "./utils/staticMethodsProxy"
-import { handleError } from "./utils/errors"
-import { createEither } from "./utils/createEither"
-import { MightFail } from "./utils/utils.type"
-import { mightFailFunction } from "./utils/mightFailFunction"
+import { type Either } from "./Either.js"
+import { makeProxyHandler } from "./utils/staticMethodsProxy.js"
+import { handleError } from "./utils/errors.js"
+import { createEither } from "./utils/createEither.js"
+import { MightFail } from "./utils/utils.type.js"
+import { mightFailFunction } from "./utils/mightFailFunction.js"
 
 /**
  * Wraps a promise in an Either to safely handle both its resolution and rejection. This function

--- a/src/utils/createEither.ts
+++ b/src/utils/createEither.ts
@@ -1,6 +1,6 @@
-import { AnyEither, EitherMode } from "./utils.type"
-import type { Either as StandardEither } from "../Either"
-import type { Either as GoEither } from "../go/Either"
+import { AnyEither, EitherMode } from "./utils.type.js"
+import type { Either as StandardEither } from "../Either.js"
+import type { Either as GoEither } from "../go/Either.js"
 
 // This is not how we intended the tuple feature to work but this is the only way we could currently get TypeScript to play nice
 // this really should just be an interator on the either object, but it's much more complicated because of TS.

--- a/src/utils/mightFailFunction.ts
+++ b/src/utils/mightFailFunction.ts
@@ -1,7 +1,7 @@
-import { type Either } from "../Either"
-import { handleError } from "./errors"
-import { createEither } from "./createEither"
-import { MightFailFunction } from "./utils.type"
+import { type Either } from "../Either.js"
+import { handleError } from "./errors.js"
+import { createEither } from "./createEither.js"
+import { MightFailFunction } from "./utils.type.js"
 
 export const mightFailFunction: MightFailFunction<"standard"> = async function <T, E extends Error = Error>(
   promise: T

--- a/src/utils/staticMethodsProxy.ts
+++ b/src/utils/staticMethodsProxy.ts
@@ -1,4 +1,4 @@
-import { EitherMode, MightFailFunction } from "./utils.type"
+import { EitherMode, MightFailFunction } from "./utils.type.js"
 
 export const makeProxyHandler = <TMightFailFunction extends MightFailFunction<EitherMode>>(
   mightFailFunction: TMightFailFunction

--- a/src/utils/utils.type.ts
+++ b/src/utils/utils.type.ts
@@ -1,5 +1,5 @@
-import type { Either as StandardEither } from "../Either"
-import type { Either as GoEither } from "../go/Either"
+import type { Either as StandardEither } from "../Either.js"
+import type { Either as GoEither } from "../go/Either.js"
 
 export type EitherMode = "standard" | "go" | "any"
 


### PR DESCRIPTION
Issue #25 

Node module resolution can't map the imports properly without having `.js` file extensions unlike Bun does. As I've been using Bun for all of my projects with `might-fail` I haven't noticed this problem because the module resolution is set to `bundler` and is handled entirely by Bun.